### PR TITLE
Feat/lyapunov discrete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__
 .vscode/
+.venv/
 .DS_Store
 *.egg-info/
 tests/*.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Standardized handling of `sample_times` in wrappers that support sampled outputs by explicitly validating user input and constructing internal sampling arrays only when needed.
   - Updated `dig` observable validation so the observable must be callable and return a 1D NumPy array with one value per input state.
   - Improved validation and normalization of wrapper inputs for periodic-orbit, manifold, transport, escape, Hurst, and recurrence diagnostics.
+  - The Lyapunov exponent API now exposes the analytical QR procedure (after Eckmann-Ruelle) explicitly through the `method` argument:
+    - `method="ER"` now selects the analytical QR-based approach (available only for 2D systems).
+    - `method="QR"` now consistently uses the modifed Gram-Schmidt QR decomposition, independent of system dimension.
+    - `method=QR_HH` uses Householder QR decomposition via `np.linalg.qr`.
+  - The previous implicit behavior where method="QR" automatically switched to the Eckmann–Ruelle algorithm for 2D systems has been removed. Existing code relying on this optimization should now explicitly set `ds.lyapunov(..., method="ER")`.
 
 - `ContinuousDynamicalSystem` class:
   - Reorganized imports and internal plumbing to use the new continuous-time module layout.
@@ -137,6 +142,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixed `GALI` computation by using stable QR-based volume evaluation.
   - Fixed `CLV_angles` validation so subspace and pair indices are checked against the number of computed CLVs rather than the ambient phase-space dimension.
   - Removed a stray debug `print(iter_time)` from `manifold()`.
+  - Added validation to prevent the use of `method="ER"` for systems with dimension greater than 2, raising a clear error instead of silently falling back to another implementation.
 
 - `ContinuousDynamicalSystem` class:
   - Fixed wrapper regressions introduced during the continuous-time refactor in trajectory, reduced-map, Lyapunov, CLV, SALI, LDI, GALI, RTE, and Hurst-related methods.

--- a/src/pynamicalsys/core/discrete_dynamical_systems.py
+++ b/src/pynamicalsys/core/discrete_dynamical_systems.py
@@ -30,7 +30,6 @@ from pynamicalsys.common.recurrence_quantification_analysis import (
     calculate_threshold,
 )
 
-from pynamicalsys.common.linalg import qr, householder_qr
 
 from pynamicalsys.common.differentiation import finite_difference_jacobian
 
@@ -2285,8 +2284,9 @@ class DiscreteDynamicalSystem:
             System parameters of shape (p,) passed to mapping function
         method : str, optional
             Computation method:
-            - "QR": QR decomposition
-            - "QR_HH": Householder QR (more stable)
+            - "ER": Analytical QR decomposition, after Eckmann and Ruelle [1]. Only for 2d systems
+            - "QR": QR decomposition (modifed Gram-Schmidt)
+            - "QR_HH": Householder QR (more stable, uses np.linalg.qr)
         return_history : bool, optional
             If True, returns convergence history (default False)
         sample_times : Optional[Union[NDArray[np.float64], Sequence[int]]], optional
@@ -2374,12 +2374,12 @@ class DiscreteDynamicalSystem:
         if not isinstance(method, str):
             raise TypeError("method must be a string")
         method = method.upper()
-        if method not in ("QR", "QR_HH"):
-            raise ValueError("method must be 'QR' or 'QR_HH'")
+        if method not in ("ER", "QR", "QR_HH"):
+            raise ValueError("method must be 'ER', 'QR', or 'QR_HH'")
 
         # Validate method for system dimension
-        if method == "QR" and self.__system_dimension == 2:
-            method = "ER"  # Fallback to QR for higher dimensions
+        if method == "ER" and self.__system_dimension > 2:
+            raise ValueError("method ER is only valid for 2 dimensional systems.")
 
         sample_times_arr: NDArray[np.int64] | None = None
         if return_history:
@@ -2442,7 +2442,6 @@ class DiscreteDynamicalSystem:
                         log_base,
                     )
             else:
-                qr_func = qr if method == "QR" else householder_qr
                 result, u = lyapunov_qr(
                     u,
                     parameters,
@@ -2451,7 +2450,7 @@ class DiscreteDynamicalSystem:
                     self.__jacobian,
                     num_exponents,
                     sample_times_arr,
-                    qr_func,
+                    method,
                     return_history,
                     transient_time,
                     log_base,

--- a/src/pynamicalsys/discrete_time/lyapunov.py
+++ b/src/pynamicalsys/discrete_time/lyapunov.py
@@ -21,7 +21,7 @@ import numpy as np
 from numba import njit
 from numpy.typing import NDArray
 from pynamicalsys.common.types import int_t, numeric_t, map_t, jacobian_t
-from pynamicalsys.common.linalg import householder_qr
+from pynamicalsys.common.linalg import qr
 
 
 @njit
@@ -350,9 +350,7 @@ def lyapunov_qr(
     jacobian: jacobian_t,
     num_exponents: int,
     sample_times: Optional[NDArray[np.integer]] = None,
-    QR: Callable[
-        [NDArray[np.float64]], Tuple[NDArray[np.float64], NDArray[np.float64]]
-    ] = np.linalg.qr,
+    method: str = "QR",
     return_history: bool = False,
     transient_time: Optional[int_t] = None,
     log_base: numeric_t = np.e,
@@ -383,9 +381,11 @@ def lyapunov_qr(
     sample_times : Optional[NDArray[np.integer]], optional
         Array of iteration times at which the finite-time Lyapunov exponents
         are recorded when `return_history=True`.
-    QR : Callable[[NDArray[np.float64]], Tuple[NDArray[np.float64], NDArray[np.float64]]], optional
-        QR decomposition routine used to orthonormalize the perturbation
-        vectors. Default is `qr`.
+    method : str, optional
+        Computation method:
+        - "ER": Analytical QR decomposition, after Eckmann and Ruelle [2]. Only for 2d systems
+        - "QR": QR decomposition (modified Gram-Schmidt)
+        - "QR_HH": Householder QR (more stable)
     return_history : bool, optional
         If True, return the finite-time Lyapunov exponents evaluated at
         `sample_times`. Otherwise, return only the final exponent estimates.
@@ -426,14 +426,16 @@ def lyapunov_qr(
     ----------
     [1] A. Wolf et al., "Determining Lyapunov exponents from a time series",
         Physica D 16, 285-317 (1985).
+    [2] Eckmann & Ruelle, Rev. Mod. Phys 57, 617 (1985)
     """
+
     np.random.seed(seed)
     neq = len(u)
     num_samples = len(sample_times) if sample_times is not None else 0
     log_den = np.log(log_base)
 
     v = np.ascontiguousarray(np.random.rand(neq, num_exponents))
-    v, _ = QR(v)
+    v, _ = qr(v)
     exponents = np.zeros(num_exponents, dtype=np.float64)
     u = np.ascontiguousarray(u.copy())
 
@@ -454,7 +456,10 @@ def lyapunov_qr(
         for i in range(num_exponents):
             v[:, i] = J @ np.ascontiguousarray(v[:, i])
 
-        v, R = QR(v)
+        if method == "QR":
+            v, R = qr(v)
+        else:
+            v, R = np.linalg.qr(v)
         exponents += np.log(np.abs(np.diag(R)))
 
         if (
@@ -620,7 +625,7 @@ def finite_time_lyapunov(
                 mapping,
                 jacobian,
                 num_exponents,
-                QR=householder_qr,
+                method=method,
                 log_base=log_base,
             )
 

--- a/tests/discrete-time/test_lyapunov.ipynb
+++ b/tests/discrete-time/test_lyapunov.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "id": "b4ba6048",
    "metadata": {},
    "outputs": [],
@@ -14,7 +14,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
+   "id": "3710635f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'1.5.4.dev52+ga0c8c9f58.d20260528'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pynamicalsys\n",
+    "pynamicalsys.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
    "id": "80f8f725",
    "metadata": {},
    "outputs": [],
@@ -28,17 +50,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "id": "8f1d8e93",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([ 0.2841174, -0.2841174])"
+       "array([ 0.28411636, -0.28411636])"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -49,17 +71,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "id": "9f1f6267",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.2841173973757471"
+       "0.2841149976009825"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -70,24 +92,83 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "id": "7bfaf38d",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "array([0.99456997, 0.35607948, 0.23808266, ..., 0.28411851, 0.28411784,\n",
-       "       0.2841174 ], shape=(1000000,))"
+       "array([ 0.88174182,  0.1729671 , -0.23498385, ...,  0.28411611,\n",
+       "        0.28411544,  0.284115  ], shape=(1000000,))"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "ds.lyapunov(u, total_time, parameters=parameters, num_exponents=1, return_history=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "d89cb15c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 0.2841174, -0.2841174])"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ds.lyapunov(u, total_time, method=\"ER\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "f99e721f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "491 ms ± 8.7 ms per loop (mean ± std. dev. of 5 runs, 5 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -n 5 -r 5\n",
+    "ds.lyapunov(u, total_time)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "25f24715",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "251 ms ± 2.73 ms per loop (mean ± std. dev. of 5 runs, 5 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit -n 5 -r 5\n",
+    "ds.lyapunov(u, total_time, method=\"ER\")"
    ]
   },
   {
@@ -529,7 +610,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pynamicalsys-dev",
+   "display_name": ".venv (3.13.7)",
    "language": "python",
    "name": "python3"
   },
@@ -543,7 +624,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.13.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

This PR makes the Eckmann–Ruelle (`ER`) method for Lyapunov exponent computation explicit in discrete-time systems.

### Changes
- Added `method="ER"` as an explicit option for 2D systems.
- Removed the previous implicit fallback where `method="QR"` automatically used the ER algorithm in 2D.
- Added validation to prevent using `ER` for systems with dimension > 2.
- Simplified QR backend selection and updated documentation.

### Notes
This introduces a small behavioral change: users relying on the previous automatic ER selection in 2D should now explicitly use:

```python
ds.lyapunov(..., method="ER")
```